### PR TITLE
allow kibana to create indexes

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,6 @@ variable "vmSizeAllNodes" {
 variable "esAdditionalYaml" {
   description = "additional configuration"
   type = "string"
-  default = "action.auto_create_index: .security*,.monitoring*,.watches,.triggered_watches,.watcher-history*,.ml*\nxpack.monitoring.collection.enabled: true\n"
+  default = "action.auto_create_index: .security*,.monitoring*,.watches,.triggered_watches,.watcher-history*,.kibana*,.ml*\nxpack.monitoring.collection.enabled: true\n"
 }
 


### PR DESCRIPTION
Allow Kibana to create indexes in the cluster. This will allow us to see the content of the Dead Letter Queue in Kibana