### PR TITLE
Configure Bastion IPs from vault

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -132,7 +132,7 @@ resource "azurerm_network_security_rule" "bastion_devops_rule" {
   source_port_range           = "*"
   destination_port_range      = "9200"
   source_address_prefix       = "${data.azurerm_key_vault_secret.bastion_devops_ip.value}"
-  destination_address_prefix  = "*"
+  destination_application_security_group_ids = ["${data.azurerm_application_security_group.data_asg.id}"]
   resource_group_name         = "${azurerm_resource_group.elastic-resourcegroup.name}"
   network_security_group_name = "${data.azurerm_network_security_group.cluster_nsg.name}"
   depends_on = ["azurerm_template_deployment.elastic-iaas"]
@@ -149,7 +149,7 @@ resource "azurerm_network_security_rule" "bastion_dev_rule" {
   source_port_range           = "*"
   destination_port_range      = "9200"
   source_address_prefix       = "${data.azurerm_key_vault_secret.bastion_dev_ip.value}"
-  destination_address_prefix  = "*"
+  destination_application_security_group_ids = ["${data.azurerm_application_security_group.data_asg.id}"]
   resource_group_name         = "${azurerm_resource_group.elastic-resourcegroup.name}"
   network_security_group_name = "${data.azurerm_network_security_group.cluster_nsg.name}"
   depends_on = ["azurerm_template_deployment.elastic-iaas"]


### PR DESCRIPTION
This has been tested on sandbox and works.  The IPs are setup correctly.  Faked
a prod deployment and it didn't add the dev rule but kept the devops rule.  

Does need laoding of IPs secrets on nonprod and prod vaults.