### PR TITLE
updated the aks_core_vnet name and rg values

### DIFF
--- a/aks.tf
+++ b/aks.tf
@@ -4,8 +4,8 @@ provider "azurerm" {
 
 data "azurerm_virtual_network" "aks_core_vnet" {
   provider            = "azurerm.aks-infra"
-  name                = "core-${local.env}-vnet"
-  resource_group_name = "aks-infra-${local.env}-rg"
+  name                = "cft-${local.env}-vnet"
+  resource_group_name = "cft-${local.env}-network-rg"
 }
 
 data "azurerm_subnet" "aks-00" {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-7694

### Change description ###

After the recent demo switchover the rule had to manually be added to the elasticsearch nsg so that the AKS cluster could reach elasticsearch..

I have now updated data **"azurerm_virtual_network" "aks_core_vnet"** to reference the new vnet so that the correct rule gets applied for the new AKS clusters on elastic search.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
