### PR TITLE
Allow data disk sizing

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ resource "azurerm_template_deployment" "elastic-iaas" {
     dataNodesAreMasterEligible       = var.dataNodesAreMasterEligible ? "Yes" : "No"
     vmDataNodeCount                  = var.vmDataNodeCount
     vmDataDiskCount                  = var.vmDataDiskCount
+    vmDataDiskSize                   = var.vmDataDiskSize
     vmClientNodeCount                = var.vmClientNodeCount
     storageAccountType               = var.storageAccountType
     dataStorageAccountType           = var.dataStorageAccountType
@@ -163,7 +164,7 @@ resource "azurerm_network_security_rule" "bastion_es_rule" {
   protocol                                   = "Tcp"
   source_port_range                          = "*"
   destination_port_range                     = "9200"
-  source_address_prefixes                    = var.subscription == "prod" || var.subscription == "ethosldata" ? ["10.11.8.32/27"] : [ "10.11.72.32/27"]
+  source_address_prefixes                    = var.subscription == "prod" || var.subscription == "ethosldata" ? ["10.11.8.32/27"] : ["10.11.72.32/27"]
   destination_application_security_group_ids = [data.azurerm_application_security_group.data_asg.id]
   resource_group_name                        = azurerm_resource_group.elastic-resourcegroup.name
   network_security_group_name                = data.azurerm_network_security_group.cluster_nsg.name
@@ -211,7 +212,7 @@ resource "azurerm_network_security_rule" "bastion_ssh_rule" {
   protocol                    = "Tcp"
   source_port_range           = "*"
   destination_port_range      = "22"
-  source_address_prefixes     = var.subscription == "prod" || var.subscription == "ethosldata" ? ["10.11.8.32/27"] : [ "10.11.72.32/27"]
+  source_address_prefixes     = var.subscription == "prod" || var.subscription == "ethosldata" ? ["10.11.8.32/27"] : ["10.11.72.32/27"]
   destination_address_prefix  = data.azurerm_subnet.elastic-subnet.address_prefix
   resource_group_name         = azurerm_resource_group.elastic-resourcegroup.name
   network_security_group_name = data.azurerm_network_security_group.cluster_nsg.name

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,17 @@ variable "vmDataDiskCount" {
   description = "number of data node's disks"
   type        = number
   default     = 1
+
+}
+variable "vmDataDiskSize" {
+  description = "The disk size of each attached data disk"
+  type        = string
+  # Default to Large now so we can override this, but to avoid breaking changes in the meantime
+  default = "1TiB"
+  validation {
+    condition     = contains(["32GiB", "64GiB", "128GiB", "256GiB", "512GiB", "1TiB", "2TiB", "4TiB", "8TiB", "16TiB", "32TiB"], var.vmDataDiskSize)
+    error_message = "Please define a data disk size that matches the condition"
+  }
 }
 
 variable "vmClientNodeCount" {
@@ -111,15 +122,15 @@ variable "alerts_email" {
 }
 
 variable "vmHostNamePrefix" {
-  description= "The prefix to use for resources and hostnames when naming virtual machines in the cluster. Can be up to 5 characters in length, must begin with an alphanumeric character and can contain alphanumeric and hyphen characters. Hostnames are used for resolution of master nodes so if you are deploying a cluster into an existing virtual network containing an existing Elasticsearch cluster, be sure to set this to a unique prefix to differentiate the hostnames of this cluster from an existing cluster"
+  description = "The prefix to use for resources and hostnames when naming virtual machines in the cluster. Can be up to 5 characters in length, must begin with an alphanumeric character and can contain alphanumeric and hyphen characters. Hostnames are used for resolution of master nodes so if you are deploying a cluster into an existing virtual network containing an existing Elasticsearch cluster, be sure to set this to a unique prefix to differentiate the hostnames of this cluster from an existing cluster"
 }
 
 variable "esHeapSize" {
   description = "The size, in megabytes, of memory to allocate on each Elasticsearch node for the JVM heap."
-  type        = number 
+  type        = number
   default     = 0
 }
 
 variable "vNetLoadBalancerIp" {
-  description= "The static IP address for the internal load balancer. This must be an available IP address in the specified subnet"
+  description = "The static IP address for the internal load balancer. This must be an available IP address in the specified subnet"
 }


### PR DESCRIPTION


This is based on **our fork** of the ARM templates in use, which changes the allowed values for `vmDataDiskSize` to this https://github.com/hmcts/azure-marketplace/blob/DTSPO-17635_7.11.1/src/mainTemplate.json#L743-L758.

This change, allows us to override that default value of 1Tb, so we can finetune our data disk sizes that are attached to all the ccd-data VMS.
I have left the default as matching the default value in the ARM template so there are no changes, but written functionality so we can override this via tfvars files like so https://github.com/hmcts/ccd-elastic-search/blob/master/demo.tfvars in the environments we wish.
There is also a few terraform fmt changes for consistency.


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
